### PR TITLE
Cambio en el string Item.KEYWORDS para mayor claridad

### DIFF
--- a/EasyGoogleMobileAds/Scripts/Editor/EasyGoogleMobileAdsEditor.cs
+++ b/EasyGoogleMobileAds/Scripts/Editor/EasyGoogleMobileAdsEditor.cs
@@ -93,7 +93,7 @@ public class EasyGoogleMobileAdsEditor : Editor {
 				{Item.TARGET_SETTINGS, "Ajustes de Audiencia"}, 
 				{Item.GENDER, "Género"},
 				{Item.GENDER_HINT, "El Género para el que este juego está destinado.\n\nMALE para masculino\nFEMALE para femenino\nUNKNOWN para ambos."}, 
-				{Item.KEYWORDS, "Palabras clave"},		
+				{Item.KEYWORDS, "Palabras clave (separadas por coma)"},		
 				{Item.KEYWORDS_HINT, "Palabras clave relacionadas con el juego separadas por comas."},
 				{Item.ABOUT_TITLE, "Sobre este componente"},	
 				{Item.ABOUT_DESC, "https://www.youtube.com/juande"},	


### PR DESCRIPTION
Buenas Juande, lo unico que le veo al plugin es a la hora de definir keywords el string del editor no especifica como hay que escribirlos (si separados por coma o espacios) en ingles veo que lo especificas, lo he cambiado en el codigo por si quieres incorporarlo. Saludoss
